### PR TITLE
Handle ERR_INTERNET_DISCONNECTED exceptions

### DIFF
--- a/gym_chrome_dino/game/chrome_dino.py
+++ b/gym_chrome_dino/game/chrome_dino.py
@@ -4,6 +4,7 @@
 # Licensed under the MIT License - https://opensource.org/licenses/MIT
 
 from selenium import webdriver
+from selenium.common.exceptions import WebDriverException
 from selenium.webdriver.chrome.options import Options
 from selenium.webdriver.common.keys import Keys
 
@@ -11,7 +12,7 @@ class ChromeDino():
 
     def __init__(self, chrome_driver_path=None, render=False):
         self.webdriver = webdriver.Chrome(executable_path=chrome_driver_path, options=self._get_options(render))
-        self.webdriver.get('chrome://dino')
+        self._load_game()
 
     def _get_options(self, render):
         options = Options()
@@ -36,7 +37,7 @@ class ChromeDino():
         return self.jump()
 
     def restart(self):
-        self.webdriver.get('chrome://dino')
+        self._load_game()
         return self.start()
 
     def get_canvas(self):
@@ -44,3 +45,10 @@ class ChromeDino():
 
     def close(self):
         self.webdriver.close()
+
+    def _load_game(self):
+        try:
+            self.webdriver.get('chrome://dino')
+        except WebDriverException as e:
+            if 'error: net::ERR_INTERNET_DISCONNECTED' not in e.msg:
+                raise


### PR DESCRIPTION
### Summary

The webdriver is now throwing this exception when opening the Chrome Dino game. My guess is because it thinks the internet
has been disconnected since it's an "offline" Chrome game. Without handling the exception, the environment doesn't work anymore.

### Testing

I wrote a simple script (`test.py`) with a random agent playing the game.

```
import gym
import gym_chrome_dino
import random

random.seed(0)

env = gym.make("ChromeDino-v0")
s = env.reset()
done = False
total_reward = 0

while not done:
    a = random.choice([0, 1, 2])
    s_prime, r, done, _ = env.step(a)
    total_reward += r

print(f"Total Reward: {total_reward}")
```

**Before** this change, the script would die with the following exception being thrown in the console.

```
Traceback (most recent call last):
  File "test.py", line 4, in <module>
    env = gym.make("ChromeDino-v0")
  File "/home/reyallan/Documents/Projects/gym-chrome-dino/venv/gym-chrome-dino/lib/python3.6/site-packages/gym/envs/registration.py", line 235, in make
    return registry.make(id, **kwargs)
  File "/home/reyallan/Documents/Projects/gym-chrome-dino/venv/gym-chrome-dino/lib/python3.6/site-packages/gym/envs/registration.py", line 129, in make
    env = spec.make(**kwargs)
  File "/home/reyallan/Documents/Projects/gym-chrome-dino/venv/gym-chrome-dino/lib/python3.6/site-packages/gym/envs/registration.py", line 90, in make
    env = cls(**_kwargs)
  File "/home/reyallan/Documents/Projects/gym-chrome-dino/gym_chrome_dino/envs/chrome_dino_env.py", line 30, in __init__
    self.game = ChromeDino(chrome_driver_path=chrome_driver_path, render=render)
  File "/home/reyallan/Documents/Projects/gym-chrome-dino/gym_chrome_dino/game/chrome_dino.py", line 14, in __init__
    self.webdriver.get('chrome://dino')
  File "/home/reyallan/Documents/Projects/gym-chrome-dino/venv/gym-chrome-dino/lib/python3.6/site-packages/selenium/webdriver/remote/webdriver.py", line 333, in get
    self.execute(Command.GET, {'url': url})
  File "/home/reyallan/Documents/Projects/gym-chrome-dino/venv/gym-chrome-dino/lib/python3.6/site-packages/selenium/webdriver/remote/webdriver.py", line 321, in execute
    self.error_handler.check_response(response)
  File "/home/reyallan/Documents/Projects/gym-chrome-dino/venv/gym-chrome-dino/lib/python3.6/site-packages/selenium/webdriver/remote/errorhandler.py", line 242, in check_response
    raise exception_class(message, screen, stacktrace)
selenium.common.exceptions.WebDriverException: Message: unknown error: net::ERR_INTERNET_DISCONNECTED
  (Session info: chrome=97.0.4692.99)
```

**After** this change, the environment works and the random agent is able to act on it.

```
> python test.py
Total Reward: 57
```